### PR TITLE
Migrate to parent POM version 0.10.0

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -5,9 +5,4 @@
 		<artifactId>tycho-build</artifactId>
 		<version>2.7.5</version>
 	</extension>
-	<extension>
-		<groupId>org.palladiosimulator</groupId>
-		<artifactId>tycho-tp-refresh-maven-plugin</artifactId>
-		<version>0.2.6</version>
-	</extension>
 </extensions>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.palladiosimulator</groupId>
         <artifactId>eclipse-parent-updatesite</artifactId>
-        <version>0.9.0</version>
+        <version>0.10.0</version>
     </parent>
 
     <groupId>org.somox</groupId>
@@ -18,7 +18,7 @@
 
 
     <properties>
-        <org.palladiosimulator.maven.tychotprefresh.tplocation.2>${project.basedir}/releng/org.somox.targetplatform/org.somox.targetplatform.target</org.palladiosimulator.maven.tychotprefresh.tplocation.2>
+        <targetPlatform.relativePath>releng/org.somox.targetplatform/tp.target</targetPlatform.relativePath>
     </properties>
 
     <modules>

--- a/releng/org.somox.targetplatform/org.somox.targetplatform.target
+++ b/releng/org.somox.targetplatform/org.somox.targetplatform.target
@@ -1,61 +1,44 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<?pde version="3.8"?>
-<target name="SoMoX - SOftware MOdel eXtractor" sequenceNumber="1">
-    <locations>
-        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner"
-            includeSource="false" refresh="true" type="InstallableUnit">
-            <unit id="de.uka.ipd.sdq.identifier.feature.feature.group" version="0.0.0" />
-            <repository
-                location="https://updatesite.palladio-simulator.com/palladio-core-commons/nightly/" />
-        </location>
-        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner"
-            includeSource="false" refresh="true" type="InstallableUnit">
-            <unit id="org.palladiosimulator.pcm.feature.feature.group" version="0.0.0" />
-            <repository
-                location="https://updatesite.palladio-simulator.com/palladio-core-pcm/nightly/" />
-        </location>
-        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner"
-            includeSource="false" refresh="true" type="InstallableUnit">
-            <unit id="de.uka.ipd.sdq.workflow" version="0.0.0" />
-            <unit id="de.uka.ipd.sdq.workflow.mdsd" version="0.0.0" />
-            <repository
-                location="https://updatesite.palladio-simulator.com/palladio-supporting-workflowengine/nightly/" />
-        </location>
-        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner"
-            includeSource="false" refresh="true" type="InstallableUnit">
-            <repository
-                location="https://updatesite.palladio-simulator.com/palladio-supporting-branding/nightly/" />
-            <unit id="org.palladiosimulator.branding.feature.feature.group" version="2.0.0" />
-        </location>
-        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner"
-            includeSource="false" refresh="true" type="InstallableUnit">
-            <unit id="org.palladiosimulator.pcm.edit" version="0.0.0" />
-            <repository
-                location="https://updatesite.palladio-simulator.com/palladio-editors-commons/nightly/" />
-        </location>
-        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner"
-            includeSource="false" refresh="true" type="InstallableUnit">
-            <repository
-                location="https://updatesite.palladio-simulator.com/palladio-thirdparty-library/nightly/" />
-            <unit id="org.jgrapht.feature.feature.group"
-                version="1.3.0" />
-        </location>
-        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner"
-            includeSource="false" refresh="true" type="InstallableUnit">
-            <unit id="tools.mdsd.jamopp.feature.feature.group" version="0.0.0" />
-            <repository location="https://updatesite.mdsd.tools/jamopp/nightly/" />
-        </location>
-        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner"
-            includeSource="false" refresh="true" type="InstallableUnit">
-            <unit id="tools.mdsd.library.emfeditutils" version="0.0.0" />
-            <repository location="https://updatesite.mdsd.tools/library-emfeditutils/nightly/" />
-        </location>
-        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner"
-            includeSource="false" type="InstallableUnit">
-            <repository location="https://download.eclipse.org/releases/2023-03/202303151000/" />
-            <unit id="org.eclipse.gmf.feature.group" version="0.0.0" />
-            <unit id="org.eclipse.emf.sdk.feature.group" version="0.0.0" />
-            <unit id="org.apache.commons.io" version="0.0.0" />
-        </location>
-    </locations>
+<?pde version="3.8"?><target name="SoMoX - SOftware MOdel eXtractor" sequenceNumber="1">
+	<locations>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" refresh="true" type="InstallableUnit">
+			<unit id="de.uka.ipd.sdq.identifier.feature.feature.group" version="0.0.0"/>
+			<repository location="https://updatesite.palladio-simulator.com/palladio-core-commons/nightly/"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" refresh="true" type="InstallableUnit">
+			<unit id="org.palladiosimulator.pcm.feature.feature.group" version="0.0.0"/>
+			<repository location="https://updatesite.palladio-simulator.com/palladio-core-pcm/nightly/"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" refresh="true" type="InstallableUnit">
+			<unit id="de.uka.ipd.sdq.workflow" version="0.0.0"/>
+			<unit id="de.uka.ipd.sdq.workflow.mdsd" version="0.0.0"/>
+			<repository location="https://updatesite.palladio-simulator.com/palladio-supporting-workflowengine/nightly/"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" refresh="true" type="InstallableUnit">
+			<repository location="https://updatesite.palladio-simulator.com/palladio-supporting-branding/nightly/"/>
+			<unit id="org.palladiosimulator.branding.feature.feature.group" version="2.0.0"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" refresh="true" type="InstallableUnit">
+			<unit id="org.palladiosimulator.pcm.edit" version="0.0.0"/>
+			<repository location="https://updatesite.palladio-simulator.com/palladio-editors-commons/nightly/"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" refresh="true" type="InstallableUnit">
+			<repository location="https://updatesite.palladio-simulator.com/palladio-thirdparty-library/nightly/"/>
+			<unit id="org.jgrapht.feature.feature.group" version="1.3.0"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" refresh="true" type="InstallableUnit">
+			<unit id="tools.mdsd.jamopp.feature.feature.group" version="0.0.0"/>
+			<repository location="https://updatesite.mdsd.tools/jamopp/nightly/"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" refresh="true" type="InstallableUnit">
+			<unit id="tools.mdsd.library.emfeditutils" version="0.0.0"/>
+			<repository location="https://updatesite.mdsd.tools/library-emfeditutils/nightly/"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
+			<repository location="https://download.eclipse.org/releases/2023-03/202303151000/"/>
+			<unit id="org.eclipse.gmf.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.emf.sdk.feature.group" version="0.0.0"/>
+			<unit id="org.apache.commons.io" version="0.0.0"/>
+		</location>
+	</locations>
 </target>

--- a/releng/org.somox.targetplatform/tp.target
+++ b/releng/org.somox.targetplatform/tp.target
@@ -1,36 +1,37 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<?pde version="3.8"?><target name="SoMoX - SOftware MOdel eXtractor" sequenceNumber="1">
+<?pde version="3.8"?><target name="SoMoX - SOftware MOdel eXtractor" sequenceNumber="2">
 	<locations>
-		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" refresh="true" type="InstallableUnit">
+		<location type="Target" uri="mvn:org.palladiosimulator:palladio-target-platforms:0.1.0:target:palladio-2023-03"/>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
 			<unit id="de.uka.ipd.sdq.identifier.feature.feature.group" version="0.0.0"/>
 			<repository location="https://updatesite.palladio-simulator.com/palladio-core-commons/nightly/"/>
 		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" refresh="true" type="InstallableUnit">
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
 			<unit id="org.palladiosimulator.pcm.feature.feature.group" version="0.0.0"/>
 			<repository location="https://updatesite.palladio-simulator.com/palladio-core-pcm/nightly/"/>
 		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" refresh="true" type="InstallableUnit">
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
 			<unit id="de.uka.ipd.sdq.workflow" version="0.0.0"/>
 			<unit id="de.uka.ipd.sdq.workflow.mdsd" version="0.0.0"/>
 			<repository location="https://updatesite.palladio-simulator.com/palladio-supporting-workflowengine/nightly/"/>
 		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" refresh="true" type="InstallableUnit">
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
 			<repository location="https://updatesite.palladio-simulator.com/palladio-supporting-branding/nightly/"/>
-			<unit id="org.palladiosimulator.branding.feature.feature.group" version="2.0.0"/>
+			<unit id="org.palladiosimulator.branding.feature.feature.group" version="0.0.0"/>
 		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" refresh="true" type="InstallableUnit">
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
 			<unit id="org.palladiosimulator.pcm.edit" version="0.0.0"/>
 			<repository location="https://updatesite.palladio-simulator.com/palladio-editors-commons/nightly/"/>
 		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" refresh="true" type="InstallableUnit">
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
 			<repository location="https://updatesite.palladio-simulator.com/palladio-thirdparty-library/nightly/"/>
-			<unit id="org.jgrapht.feature.feature.group" version="1.3.0"/>
+			<unit id="org.jgrapht.feature.feature.group" version="0.0.0"/>
 		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" refresh="true" type="InstallableUnit">
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
 			<unit id="tools.mdsd.jamopp.feature.feature.group" version="0.0.0"/>
 			<repository location="https://updatesite.mdsd.tools/jamopp/nightly/"/>
 		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" refresh="true" type="InstallableUnit">
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
 			<unit id="tools.mdsd.library.emfeditutils" version="0.0.0"/>
 			<repository location="https://updatesite.mdsd.tools/library-emfeditutils/nightly/"/>
 		</location>


### PR DESCRIPTION
### Overview
- Migrate from parent POM version `0.9.0` to the new parent POM version `0.10.0`
- Locally verified build success

### Changes
- In `pom.xml`:
  - Parent POM updated from `0.9.0` to `0.10.0`  
  - Renamed property `org.palladiosimulator.maven.tychotprefresh.tplocation.2` to `targetPlatform.relativePath` and trimmed its path value to start at `releng`  
- In `.mvn/extensions.xml`:
  - Removed `<extension>` block for `org.palladiosimulator:tycho-tp-refresh-maven-plugin`  
- In the target platform `org.somox.targetplatform.target`:
  - Inserted new `<location>` with URI `mvn:org.palladiosimulator:palladio-target-platforms:0.1.0:target:palladio-2023-03`, since the Palladio target platform is now decoupled from the parent POM  
  - Unified all `includeSource` attributes by setting them to `false`, as the value must be the same across all locations to prevent resolution failure  
  - Removed specifics of the `tycho-tp-refresh-maven-plugin` to be standard-compliant:  
    - Removed any `<location filter="release">` entries  
    - Removed `filter="nightly"` attributes  
    - Removed all `refresh="true"` attributes and, where present, set each `<unit>`’s `version` attribute to `0.0.0`  
  - Added indentation to improve readability  
  - Renamed to the recommended name `tp.target`